### PR TITLE
Update footer to dynamically display current year instead of a hardcoded year

### DIFF
--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -42,7 +42,7 @@
 
     <footer class="border-top footer text-muted">
         <div class="container">
-            &copy; 2024 - NailManagement - <a asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>
+            &copy; @DateTime.Now.Year - NailManagement - <a asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>
         </div>
     </footer>
     <script src="~/lib/jquery/dist/jquery.min.js"></script>


### PR DESCRIPTION
Closed #21 

Changed the footer in `_Layout.cshtml` to use `@DateTime.Now.Year` instead of a hardcoded year, ensuring the displayed year is always current and eliminating the need for manual updates.