### PR TITLE
Add XML documentation comments to controllers and models

### DIFF
--- a/Controllers/CustomersController.cs
+++ b/Controllers/CustomersController.cs
@@ -11,23 +11,37 @@ using NailManagement.Models;
 
 namespace NailManagement.Controllers
 {
+    /// <summary>
+    /// Controller for managing customers.
+    /// </summary>
     [Authorize]
     public class CustomersController : Controller
     {
         private readonly ApplicationDbContext _context;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CustomersController"/> class.
+        /// </summary>
+        /// <param name="context">The database context.</param>
         public CustomersController(ApplicationDbContext context)
         {
             _context = context;
         }
 
-        // GET: Customers
+        /// <summary>
+        /// Displays a list of customers.
+        /// </summary>
+        /// <returns>The view with the list of customers.</returns>
         public async Task<IActionResult> Index()
         {
             return View(await _context.Customers.ToListAsync());
         }
 
-        // GET: Customers/Details/5
+        /// <summary>
+        /// Displays the details of a specific customer.
+        /// </summary>
+        /// <param name="id">The ID of the customer.</param>
+        /// <returns>The view with the customer details.</returns>
         public async Task<IActionResult> Details(int? id)
         {
             if (id == null)
@@ -45,12 +59,16 @@ namespace NailManagement.Controllers
             return View(customer);
         }
 
-        // GET: Customers/Create
+        /// <summary>
+        /// Displays the form to create a new customer.
+        /// </summary>
+        /// <param name="phoneNumber">The phone number to pre-fill in the form.</param>
+        /// <param name="newCus">Indicates if the customer is new.</param>
+        /// <returns>The view with the create customer form.</returns>
         public IActionResult Create(string phoneNumber, bool newCus = false)
         {
             Customer customer = new Customer();
 
-            // If the phone number is passed from the appointment creation page, set the phone number to the customer
             if (!string.IsNullOrEmpty(phoneNumber))
             {
                 customer.PhoneNumber = phoneNumber;
@@ -59,30 +77,30 @@ namespace NailManagement.Controllers
             return View(customer);
         }
 
-        // POST: Customers/Create
-        // To protect from overposting attacks, enable the specific properties you want to bind to.
-        // For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
+        /// <summary>
+        /// Handles the form submission to create a new customer.
+        /// </summary>
+        /// <param name="customer">The customer to create.</param>
+        /// <returns>The view with the create customer form or redirects to the appointment creation page.</returns>
         [HttpPost]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Create([Bind("CustomerId,FirstName,LastName,Email,PhoneNumber,DateOfBirth,JoinDate,LoyaltyPoints")] Customer customer)
         {
             if (ModelState.IsValid)
             {
-                // Add the new customer to the database
                 _context.Add(customer);
                 await _context.SaveChangesAsync();
-
-
-                return RedirectToAction("Create", "Appointment", new { phoneNumber = customer.PhoneNumber});  //{ phoneNumber = customer.PhoneNumber, newCus = true });
-
+                return RedirectToAction("Create", "Appointment", new { phoneNumber = customer.PhoneNumber });
             }
 
-            // If the model is invalid, redisplay the form
             return View(customer);
         }
 
-
-        // GET: Customers/Edit/5
+        /// <summary>
+        /// Displays the form to edit an existing customer.
+        /// </summary>
+        /// <param name="id">The ID of the customer to edit.</param>
+        /// <returns>The view with the edit customer form.</returns>
         public async Task<IActionResult> Edit(int? id)
         {
             if (id == null)
@@ -98,9 +116,12 @@ namespace NailManagement.Controllers
             return View(customer);
         }
 
-        // POST: Customers/Edit/5
-        // To protect from overposting attacks, enable the specific properties you want to bind to.
-        // For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
+        /// <summary>
+        /// Handles the form submission to edit an existing customer.
+        /// </summary>
+        /// <param name="id">The ID of the customer to edit.</param>
+        /// <param name="customer">The customer to edit.</param>
+        /// <returns>The view with the edit customer form or redirects to the customer list.</returns>
         [HttpPost]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Edit(int id, [Bind("CustomerId,FirstName,LastName,Email,PhoneNumber,DateOfBirth,JoinDate,LoyaltyPoints")] Customer customer)
@@ -133,7 +154,11 @@ namespace NailManagement.Controllers
             return View(customer);
         }
 
-        // GET: Customers/Delete/5
+        /// <summary>
+        /// Displays the form to delete an existing customer.
+        /// </summary>
+        /// <param name="id">The ID of the customer to delete.</param>
+        /// <returns>The view with the delete customer form.</returns>
         public async Task<IActionResult> Delete(int? id)
         {
             if (id == null)
@@ -151,7 +176,11 @@ namespace NailManagement.Controllers
             return View(customer);
         }
 
-        // POST: Customers/Delete/5
+        /// <summary>
+        /// Handles the form submission to delete an existing customer.
+        /// </summary>
+        /// <param name="id">The ID of the customer to delete.</param>
+        /// <returns>Redirects to the customer list.</returns>
         [HttpPost, ActionName("Delete")]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> DeleteConfirmed(int id)
@@ -166,6 +195,11 @@ namespace NailManagement.Controllers
             return RedirectToAction(nameof(Index));
         }
 
+        /// <summary>
+        /// Checks if a customer exists.
+        /// </summary>
+        /// <param name="id">The ID of the customer.</param>
+        /// <returns>True if the customer exists, otherwise false.</returns>
         private bool CustomerExists(int id)
         {
             return _context.Customers.Any(e => e.CustomerId == id);

--- a/Controllers/ServicesController.cs
+++ b/Controllers/ServicesController.cs
@@ -11,22 +11,36 @@ using NailManagement.Models;
 
 namespace NailManagement.Controllers
 {
+    /// <summary>
+    /// Controller for managing services.
+    /// </summary>
     [Authorize]
     public class ServicesController : Controller
     {
         private readonly ApplicationDbContext _context;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ServicesController"/> class.
+        /// </summary>
+        /// <param name="context">The application database context.</param>
         public ServicesController(ApplicationDbContext context)
         {
             _context = context;
         }
 
-        // GET: Services
+        /// <summary>
+        /// Gets the list of all services.
+        /// </summary>
+        /// <returns>The view with the list of services.</returns>
         public IActionResult Index()
         {
             return View(ServiceDB.GetAllServices(_context));
         }
 
+        /// <summary>
+        /// Generates a report of services.
+        /// </summary>
+        /// <returns>The view with the service report.</returns>
         public async Task<IActionResult> ReportAsync()
         {
             DateOnly? latestPaymentDate = await _context.Payments
@@ -47,7 +61,11 @@ namespace NailManagement.Controllers
             return View(viewModel);
         }
 
-        // GET: Services/Details/5
+        /// <summary>
+        /// Gets the details of a specific service.
+        /// </summary>
+        /// <param name="id">The ID of the service.</param>
+        /// <returns>The view with the service details.</returns>
         public async Task<IActionResult> Details(int? id)
         {
             if (id == null)
@@ -65,15 +83,20 @@ namespace NailManagement.Controllers
             return View(service);
         }
 
-        // GET: Services/Create
+        /// <summary>
+        /// Displays the create service form.
+        /// </summary>
+        /// <returns>The view with the create service form.</returns>
         public IActionResult Create()
         {
             return View();
         }
 
-        // POST: Services/Create
-        // To protect from overposting attacks, enable the specific properties you want to bind to.
-        // For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
+        /// <summary>
+        /// Creates a new service.
+        /// </summary>
+        /// <param name="service">The service to create.</param>
+        /// <returns>The view with the created service.</returns>
         [HttpPost]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Create([Bind("ServiceId,ServiceName,Description,Price,DurationMinutes")] Service service)
@@ -87,7 +110,11 @@ namespace NailManagement.Controllers
             return View(service);
         }
 
-        // GET: Services/Edit/5
+        /// <summary>
+        /// Displays the edit service form.
+        /// </summary>
+        /// <param name="id">The ID of the service to edit.</param>
+        /// <returns>The view with the edit service form.</returns>
         public async Task<IActionResult> Edit(int? id)
         {
             if (id == null)
@@ -103,9 +130,12 @@ namespace NailManagement.Controllers
             return View(service);
         }
 
-        // POST: Services/Edit/5
-        // To protect from overposting attacks, enable the specific properties you want to bind to.
-        // For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
+        /// <summary>
+        /// Edits an existing service.
+        /// </summary>
+        /// <param name="id">The ID of the service to edit.</param>
+        /// <param name="service">The service to edit.</param>
+        /// <returns>The view with the edited service.</returns>
         [HttpPost]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Edit(int id, [Bind("ServiceId,ServiceName,Description,Price,DurationMinutes")] Service service)
@@ -138,7 +168,11 @@ namespace NailManagement.Controllers
             return View(service);
         }
 
-        // GET: Services/Delete/5
+        /// <summary>
+        /// Displays the delete service confirmation form.
+        /// </summary>
+        /// <param name="id">The ID of the service to delete.</param>
+        /// <returns>The view with the delete service confirmation form.</returns>
         public async Task<IActionResult> Delete(int? id)
         {
             if (id == null)
@@ -156,7 +190,11 @@ namespace NailManagement.Controllers
             return View(service);
         }
 
-        // POST: Services/Delete/5
+        /// <summary>
+        /// Deletes a service.
+        /// </summary>
+        /// <param name="id">The ID of the service to delete.</param>
+        /// <returns>The view with the deleted service.</returns>
         [HttpPost, ActionName("Delete")]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> DeleteConfirmed(int id)
@@ -171,6 +209,11 @@ namespace NailManagement.Controllers
             return RedirectToAction(nameof(Index));
         }
 
+        /// <summary>
+        /// Checks if a service exists.
+        /// </summary>
+        /// <param name="id">The ID of the service.</param>
+        /// <returns>True if the service exists, otherwise false.</returns>
         private bool ServiceExists(int id)
         {
             return _context.Services.Any(e => e.ServiceId == id);

--- a/Controllers/TechniciansController.cs
+++ b/Controllers/TechniciansController.cs
@@ -11,23 +11,37 @@ using NailManagement.Models;
 
 namespace NailManagement.Controllers
 {
+    /// <summary>
+    /// Controller for managing technicians.
+    /// </summary>
     [Authorize]
     public class TechniciansController : Controller
     {
         private readonly ApplicationDbContext _context;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TechniciansController"/> class.
+        /// </summary>
+        /// <param name="context">The application database context.</param>
         public TechniciansController(ApplicationDbContext context)
         {
             _context = context;
         }
 
-        // GET: Technicians
+        /// <summary>
+        /// Gets the list of technicians.
+        /// </summary>
+        /// <returns>A view of the list of technicians.</returns>
         public async Task<IActionResult> Index()
         {
             return View(await _context.Technicians.ToListAsync());
         }
 
-        // GET: Technicians/Details/5
+        /// <summary>
+        /// Gets the details of a specific technician.
+        /// </summary>
+        /// <param name="id">The technician ID.</param>
+        /// <returns>A view of the technician details, or a 404 error if not found.</returns>
         public async Task<IActionResult> Details(int? id)
         {
             if (id == null)
@@ -45,15 +59,20 @@ namespace NailManagement.Controllers
             return View(technician);
         }
 
-        // GET: Technicians/Create
+        /// <summary>
+        /// Displays the create technician form.
+        /// </summary>
+        /// <returns>A view of the create technician form.</returns>
         public IActionResult Create()
         {
             return View();
         }
 
-        // POST: Technicians/Create
-        // To protect from overposting attacks, enable the specific properties you want to bind to.
-        // For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
+        /// <summary>
+        /// Creates a new technician.
+        /// </summary>
+        /// <param name="technician">The technician to create.</param>
+        /// <returns>A redirect to the index view if successful; otherwise, the create view.</returns>
         [HttpPost]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Create([Bind("TechnicianId,Specialties,Rating,ProfilePicture,FirstName,LastName,Email,PhoneNumber,DateOfBirth")] Technician technician)
@@ -67,7 +86,11 @@ namespace NailManagement.Controllers
             return View(technician);
         }
 
-        // GET: Technicians/Edit/5
+        /// <summary>
+        /// Displays the edit technician form.
+        /// </summary>
+        /// <param name="id">The technician ID.</param>
+        /// <returns>A view of the edit technician form, or a 404 error if not found.</returns>
         public async Task<IActionResult> Edit(int? id)
         {
             if (id == null)
@@ -83,9 +106,12 @@ namespace NailManagement.Controllers
             return View(technician);
         }
 
-        // POST: Technicians/Edit/5
-        // To protect from overposting attacks, enable the specific properties you want to bind to.
-        // For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
+        /// <summary>
+        /// Edits an existing technician.
+        /// </summary>
+        /// <param name="id">The technician ID.</param>
+        /// <param name="technician">The technician to edit.</param>
+        /// <returns>A redirect to the index view if successful; otherwise, the edit view.</returns>
         [HttpPost]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Edit(int id, [Bind("TechnicianId,Specialties,Rating,ProfilePicture,FirstName,LastName,Email,PhoneNumber,DateOfBirth")] Technician technician)
@@ -118,7 +144,11 @@ namespace NailManagement.Controllers
             return View(technician);
         }
 
-        // GET: Technicians/Delete/5
+        /// <summary>
+        /// Displays the delete technician confirmation form.
+        /// </summary>
+        /// <param name="id">The technician ID.</param>
+        /// <returns>A view of the delete technician confirmation form.</returns>
         public async Task<IActionResult> Delete(int? id)
         {
             if (id == null)
@@ -136,7 +166,11 @@ namespace NailManagement.Controllers
             return View(technician);
         }
 
-        // POST: Technicians/Delete/5
+        /// <summary>
+        /// Deletes a technician.
+        /// </summary>
+        /// <param name="id">The technician ID.</param>
+        /// <returns>A redirect to the index view.</returns>
         [HttpPost, ActionName("Delete")]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> DeleteConfirmed(int id)
@@ -151,6 +185,11 @@ namespace NailManagement.Controllers
             return RedirectToAction(nameof(Index));
         }
 
+        /// <summary>
+        /// Checks if a technician exists.
+        /// </summary>
+        /// <param name="id">The technician ID.</param>
+        /// <returns>True if the technician exists; otherwise, false.</returns>
         private bool TechnicianExists(int id)
         {
             return _context.Technicians.Any(e => e.TechnicianId == id);

--- a/Models/Customer.cs
+++ b/Models/Customer.cs
@@ -4,22 +4,37 @@ using System.ComponentModel.DataAnnotations;
 
 namespace NailManagement.Models;
 
+/// <summary>
+/// Represents a customer in the nail management system.
+/// </summary>
 public partial class Customer : Person
 {
+    /// <summary>
+    /// Gets or sets the unique identifier for the customer.
+    /// </summary>
     [Key]
     public int CustomerId { get; set; }
 
+    /// <summary>
+    /// Gets or sets the date the customer joined.
+    /// </summary>
     [Display(Name = "Join Date")]
-    [DataType(DataType.Date)] 
+    [DataType(DataType.Date)]
     public DateOnly? JoinDate { get; set; }
 
-    
+    /// <summary>
+    /// Gets or sets the loyalty points of the customer.
+    /// </summary>
     [Display(Name = "Loyalty Points")]
     public int? LoyaltyPoints { get; set; }
 
-    
+    /// <summary>
+    /// Gets or sets the appointments associated with the customer.
+    /// </summary>
     public virtual ICollection<Appointment> Appointments { get; set; } = new List<Appointment>();
 
-    
+    /// <summary>
+    /// Gets or sets the loyalty points navigation property.
+    /// </summary>
     public virtual ICollection<LoyaltyPoint> LoyaltyPointsNavigation { get; set; } = new List<LoyaltyPoint>();
 }

--- a/Models/Person.cs
+++ b/Models/Person.cs
@@ -2,29 +2,67 @@
 
 namespace NailManagement.Models
 {
+    /// <summary>
+    /// Represents a person with personal information such as name, email, phone number, and date of birth.
+    /// </summary>
     public class Person
     {
+        /// <summary>
+        /// Gets or sets the first name of the person.
+        /// The first name cannot exceed 50 characters in length.
+        /// </summary>
+        /// <remarks>
+        /// This field is required.
+        /// </remarks>
         [Display(Name = "First Name")]
         [Required(ErrorMessage = "First name is required.")]
         [StringLength(50, ErrorMessage = "First name cannot be longer than 50 characters.")]
         public string FirstName { get; set; }
 
+        /// <summary>
+        /// Gets or sets the last name of the person.
+        /// The last name cannot exceed 50 characters in length.
+        /// </summary>
+        /// <remarks>
+        /// This field is required.
+        /// </remarks>
         [Display(Name = "Last Name")]
         [Required(ErrorMessage = "Last name is required.")]
         [StringLength(50, ErrorMessage = "Last name cannot be longer than 50 characters.")]
         public string LastName { get; set; }
 
+        /// <summary>
+        /// Gets or sets the email address of the person.
+        /// The email address must be in a valid format.
+        /// </summary>
+        /// <remarks>
+        /// This field is required.
+        /// </remarks>
         [Required(ErrorMessage = "Email is required")]
-        [EmailAddress(ErrorMessage = "Invalid Email Address")] 
+        [EmailAddress(ErrorMessage = "Invalid Email Address")]
         [Display(Name = "Email Address")]
         public string Email { get; set; }
 
-        [Display(Name = "Phone Number")] 
+        /// <summary>
+        /// Gets or sets the phone number of the person.
+        /// The phone number must match a specific format (e.g., (123) 456-7890 or 123-456-7890).
+        /// </summary>
+        /// <remarks>
+        /// This field is optional.
+        /// </remarks>
+        [Display(Name = "Phone Number")]
         [Phone(ErrorMessage = "Invalid phone number format.")]
         [RegularExpression(@"^\(?([0-9]{3})\)?[-. ]?([0-9]{3})[-. ]?([0-9]{4})$",
             ErrorMessage = "Invalid phone number. The phone number must be in the format (123) 456-7890 or 123-456-7890.")]
         public string? PhoneNumber { get; set; }
 
+        /// <summary>
+        /// Gets or sets the date of birth of the person.
+        /// The date of birth is displayed using a date picker in the browser.
+        /// </summary>
+        /// <remarks>
+        /// This field is optional.
+        /// </remarks>
         [Display(Name = "Date of Birth")]
         [DataType(DataType.Date)] // Date picker will be displayed in the browser
         public DateOnly? DateOfBirth { get; set; }

--- a/Models/Technician.cs
+++ b/Models/Technician.cs
@@ -4,25 +4,51 @@ using System.ComponentModel.DataAnnotations;
 
 namespace NailManagement.Models;
 
+/// <summary>
+/// Represents a technician in the nail management system.
+/// </summary>
 public partial class Technician : Person
 {
+    /// <summary>
+    /// Gets or sets the unique identifier for the technician.
+    /// </summary>
     [Key]
     public int TechnicianId { get; set; }
 
+    /// <summary>
+    /// Gets or sets the specialties of the technician.
+    /// Specialties are optional and cannot exceed 100 characters.
+    /// </summary>
     [Display(Name = "Specialties")]
     [StringLength(100, ErrorMessage = "Specialties cannot be longer than 100 characters.")]
     public string? Specialties { get; set; }
 
+    /// <summary>
+    /// Gets or sets the rating of the technician.
+    /// The rating must be between 0 and 5.
+    /// </summary>
     [Display(Name = "Rating")]
     [Range(0, 5, ErrorMessage = "Rating must be between 0 and 5.")]
     public decimal? Rating { get; set; }
 
+    /// <summary>
+    /// Gets or sets the profile picture URL of the technician.
+    /// The URL must be valid and cannot exceed 255 characters.
+    /// </summary>
     [Display(Name = "Profile Picture")]
     [Url(ErrorMessage = "Invalid URL.")]
     [StringLength(255, ErrorMessage = "Profile picture URL cannot be longer than 255 characters.")]
     public string? ProfilePicture { get; set; }
 
+    /// <summary>
+    /// Gets or sets the collection of appointments associated with the technician.
+    /// A technician can have multiple appointments.
+    /// </summary>
     public virtual ICollection<Appointment> Appointments { get; set; } = new List<Appointment>();
 
+    /// <summary>
+    /// Gets or sets the collection of staff schedules associated with the technician.
+    /// A technician can have multiple schedules.
+    /// </summary>
     public virtual ICollection<StaffSchedule> StaffSchedules { get; set; } = new List<StaffSchedule>();
 }


### PR DESCRIPTION
Added XML documentation comments to `CustomersController`, `ServicesController`, and `TechniciansController` classes and their methods. Enhanced documentation for `Customer`, `Person`, and `Technician` classes by adding XML comments to describe the classes and their properties. Removed inline comments and replaced them with XML documentation comments for improved readability and code documentation. This closes issue #40 